### PR TITLE
Update icons.css for framework7-icons v2 font-size

### DIFF
--- a/template/src/css/icons.css
+++ b/template/src/css/icons.css
@@ -51,7 +51,7 @@
   font-family: 'Framework7 Icons';
   font-weight: normal;
   font-style: normal;
-  font-size: 25px;
+  font-size: 28px;
   line-height: 1;
   letter-spacing: normal;
   text-transform: none;


### PR DESCRIPTION
Update font-size from 25px to 28px

See: [https://github.com/framework7io/framework7-icons/blob/master/README.md](https://github.com/framework7io/framework7-icons/blob/master/README.md)